### PR TITLE
Fix `clean` task globbing.

### DIFF
--- a/dist/tasks/clean.js
+++ b/dist/tasks/clean.js
@@ -25,7 +25,7 @@ if (_getConfig.tasks.clean) {
 
 	_gulp2.default.task(task.name, function (done) {
 		if (task.isValid()) {
-			(0, _del2.default)(task.src).then(function () {
+			(0, _del2.default)(task.src, { cwd: _getConfig.cwd }).then(function () {
 				return done();
 			});
 		} else {

--- a/dist/utils/TaskHelper.js
+++ b/dist/utils/TaskHelper.js
@@ -55,7 +55,10 @@ var TaskHelper = function () {
 	}, {
 		key: 'start',
 		value: function start() {
-			return _gulp2.default.src(this.src, { base: this.base });
+			return _gulp2.default.src(this.src, {
+				base: this.base,
+				cwd: _getConfig.cwd
+			});
 		}
 	}, {
 		key: 'end',
@@ -89,10 +92,7 @@ var TaskHelper = function () {
 	}, {
 		key: 'src',
 		get: function get() {
-			var srcList = Array.isArray(this.config.src) ? this.config.src : [this.config.src];
-			return srcList.map(function (path) {
-				return (0, _path.join)(_getConfig.cwd, path);
-			});
+			return this.config.src;
 		}
 	}, {
 		key: 'base',

--- a/src/tasks/clean.js
+++ b/src/tasks/clean.js
@@ -1,5 +1,5 @@
 import gulp from 'gulp';
-import { tasks } from '../utils/get-config';
+import { cwd, tasks } from '../utils/get-config';
 import del from 'del';
 import TaskHelper from '../utils/TaskHelper';
 
@@ -12,7 +12,7 @@ if ( tasks.clean ) {
 
 	gulp.task( task.name, done => {
 		if ( task.isValid() ) {
-			del( task.src ).then( () => done() );
+			del( task.src, { cwd } ).then( () => done() );
 		} else {
 			done();
 		}

--- a/src/utils/TaskHelper.js
+++ b/src/utils/TaskHelper.js
@@ -32,8 +32,7 @@ export default class TaskHelper {
 	}
 
 	get src() {
-		const srcList = Array.isArray( this.config.src ) ? this.config.src : [ this.config.src ];
-		return srcList.map( path => join( cwd, path ) );
+		return this.config.src;
 	}
 
 	get base() {
@@ -57,7 +56,10 @@ export default class TaskHelper {
 	}
 
 	start() {
-		return gulp.src( this.src, { base: this.base } );
+		return gulp.src( this.src, {
+			base: this.base,
+			cwd
+		});
 	}
 
 	end() {


### PR DESCRIPTION
Allow globbing of the 'clean' task. …Instead of prepending `cwd` to each `src` item, the `cwd` should be passed as an option to the `gulp.src()` method. This way the globbing patterns like `!` are preserved even if `cwd` is provided.

We can use the same method of adding `cwd` to the `src` paths in the `del` function in the `clean` task.